### PR TITLE
Fix DaVinci Resolve compatibility and export NetworkLocators

### DIFF
--- a/src/otio_aaf_adapter/adapters/aaf_adapter/aaf_writer.py
+++ b/src/otio_aaf_adapter/adapters/aaf_adapter/aaf_writer.py
@@ -546,6 +546,7 @@ class _TrackTranscriber:
     def aaf_sequence(self, otio_track):
         """Convert an otio Track into an aaf Sequence"""
         sequence = self.aaf_file.create.Sequence(media_kind=self.media_kind)
+        sequence.components.value = []
         length = 0
         for nested_otio_child in otio_track:
             result = self.transcribe(nested_otio_child)
@@ -668,6 +669,7 @@ class VideoTrackTranscriber(_TrackTranscriber):
         timeline_mobslot = self.compositionmob.create_timeline_slot(
             edit_rate=self.edit_rate)
         sequence = self.aaf_file.create.Sequence(media_kind=self.media_kind)
+        sequence.components.value = []
         timeline_mobslot.segment = sequence
         return timeline_mobslot, sequence
 
@@ -803,6 +805,7 @@ class AudioTrackTranscriber(_TrackTranscriber):
         timeline_mobslot.segment = opgroup
         # Sequence
         sequence = self.aaf_file.create.Sequence(media_kind=self.media_kind)
+        sequence.components.value = []
         sequence.length = total_length
         opgroup.segments.append(sequence)
         return timeline_mobslot, sequence

--- a/src/otio_aaf_adapter/adapters/aaf_adapter/aaf_writer.py
+++ b/src/otio_aaf_adapter/adapters/aaf_adapter/aaf_writer.py
@@ -286,12 +286,13 @@ def _gather_clip_mob_ids(input_otio,
     def _from_aaf_file(clip):
         """ Get the MobID from the AAF file itself."""
         mob_id = None
-        target_url = clip.media_reference.target_url
-        if os.path.isfile(target_url) and target_url.endswith("aaf"):
-            with aaf2.open(clip.media_reference.target_url) as aaf_file:
-                mastermobs = list(aaf_file.content.mastermobs())
-                if len(mastermobs) == 1:
-                    mob_id = mastermobs[0].mob_id
+        if isinstance(clip.media_reference, otio.schema.ExternalReference):
+            target_url = clip.media_reference.target_url
+            if os.path.isfile(target_url) and target_url.endswith("aaf"):
+                with aaf2.open(clip.media_reference.target_url) as aaf_file:
+                    mastermobs = list(aaf_file.content.mastermobs())
+                    if len(mastermobs) == 1:
+                        mob_id = mastermobs[0].mob_id
         return mob_id
 
     def _generate_empty_mobid(clip):

--- a/src/otio_aaf_adapter/adapters/advanced_authoring_format.py
+++ b/src/otio_aaf_adapter/adapters/advanced_authoring_format.py
@@ -223,6 +223,8 @@ def _convert_rgb_to_marker_color(rgb_dict):
         (0.0, 0.0, 0.0): otio.schema.MarkerColor.BLACK,
         (1.0, 1.0, 1.0): otio.schema.MarkerColor.WHITE,
     }
+    if not rgb_dict:
+        return otio.schema.MarkerColor.RED
 
     # convert from UInt to float
     red = float(rgb_dict["red"]) / 65535.0
@@ -695,7 +697,7 @@ def _transcribe(item, parents, edit_rate, indent=0):
             )
             if color is None:
                 color = _convert_rgb_to_marker_color(
-                    metadata["CommentMarkerColor"]
+                    metadata.get("CommentMarkerColor")
                 )
             result.color = color
 


### PR DESCRIPTION
Fixes https://github.com/AcademySoftwareFoundation/OpenTimelineIO/issues/766

DaVinci Resolve requires top level composition mobs to have a primary timecode track.
This is inline with the AAF Edit  Protocol

> **6.3 Top-level Composition** 
> ...
> A top-level composition shall contain one or more timecode tracks and include a Primary timecode track.
> Timecode tracks shall use the MobSlot::PhysicalTrackNumber property to distinguish their type

This pull request also adds exporting of media references as NetworkLocators, which helps resolve find the media.
There are still lots of caveats to getting Resolve to link to media and further testing is required.  

Linking image sequences works, the URL needs to be the first frame or this `f"[{first_frame:05d}-{last_frame:05d}]"` syntax.
https://github.com/AcademySoftwareFoundation/OpenTimelineIO/wiki/Editorial-File-Format-Notes#aaf
The image sequence needs to be strictly named and numbered, and I believe EXRS need to have embed timecode to work.
