### PR TITLE
Remove deprecated each_child and each_clip functions

### DIFF
--- a/src/otio_aaf_adapter/adapters/aaf_adapter/aaf_writer.py
+++ b/src/otio_aaf_adapter/adapters/aaf_adapter/aaf_writer.py
@@ -147,7 +147,7 @@ def validate_metadata(timeline):
     all_checks = [__check(timeline, "duration().rate")]
     edit_rate = __check(timeline, "duration().rate").value
 
-    for child in timeline.each_child():
+    for child in timeline.find_children():
         checks = []
         if _is_considered_gap(child):
             checks = [
@@ -227,7 +227,7 @@ def _gather_clip_mob_ids(input_otio,
 
     clip_mob_ids = {}
 
-    for otio_clip in input_otio.each_clip():
+    for otio_clip in input_otio.find_clips():
         if _is_considered_gap(otio_clip):
             continue
         for strategy in strategies:
@@ -249,7 +249,7 @@ def _stackify_nested_groups(timeline):
     """
     copied = copy.deepcopy(timeline)
     for track in copied.tracks:
-        for i, child in enumerate(track.each_child()):
+        for i, child in enumerate(track.find_children()):
             is_nested = isinstance(child, otio.schema.Track)
             is_parent_in_stack = isinstance(child.parent(), otio.schema.Stack)
             if is_nested and not is_parent_in_stack:
@@ -282,7 +282,7 @@ class _TrackTranscriber:
         self.compositionmob = root_file_transcriber.compositionmob
         self.aaf_file = root_file_transcriber.aaf_file
         self.otio_track = otio_track
-        self.edit_rate = next(self.otio_track.each_child()).duration().rate
+        self.edit_rate = self.otio_track.find_children()[0].duration().rate
         self.timeline_mobslot, self.sequence = self._create_timeline_mobslot()
         self.timeline_mobslot.name = self.otio_track.name
 

--- a/src/otio_aaf_adapter/adapters/advanced_authoring_format.py
+++ b/src/otio_aaf_adapter/adapters/advanced_authoring_format.py
@@ -1208,11 +1208,11 @@ def _attach_markers(collection):
 
     """
     # iterate all timeline objects
-    for timeline in collection.each_child(descended_from_type=otio.schema.Timeline):
+    for timeline in collection.find_children(descended_from_type=otio.schema.Timeline):
         tracks_map = {}
 
         # build track mapping
-        for track in timeline.each_child(descended_from_type=otio.schema.Track):
+        for track in timeline.find_children(descended_from_type=otio.schema.Track):
             metadata = track.metadata.get("AAF", {})
             slot_id = metadata.get("SlotID")
             track_number = metadata.get("PhysicalTrackNumber")
@@ -1222,7 +1222,8 @@ def _attach_markers(collection):
             tracks_map[(int(slot_id), int(track_number))] = track
 
         # iterate all tracks for their markers and attach them to the matching item
-        for current_track in timeline.each_child(descended_from_type=otio.schema.Track):
+        for current_track in timeline.find_children(
+                descended_from_type=otio.schema.Track):
             for marker in list(current_track.markers):
                 metadata = marker.metadata.get("AAF", {})
                 slot_id = metadata.get("AttachedSlotID")

--- a/tests/test_aaf_adapter.py
+++ b/tests/test_aaf_adapter.py
@@ -244,7 +244,7 @@ class AAFReaderTests(unittest.TestCase):
 
         self.assertEqual(len(timeline.audio_tracks()), 2)
 
-        clips = list(video_track.each_clip())
+        clips = video_track.find_clips()
 
         self.assertEqual(
             [
@@ -324,7 +324,7 @@ class AAFReaderTests(unittest.TestCase):
             ]
         )
 
-        clips = list(video_track.each_clip())
+        clips = video_track.find_clips()
 
         self.assertEqual(
             [item.name for item in video_track],
@@ -428,7 +428,7 @@ class AAFReaderTests(unittest.TestCase):
         video_track = video_tracks[0]
         self.assertEqual(len(video_track), 12)
 
-        clips = list(video_track.each_clip())
+        clips = video_track.find_clips()
         self.assertEqual(len(clips), 4)
 
         self.assertEqual(
@@ -633,7 +633,7 @@ class AAFReaderTests(unittest.TestCase):
             t.name = ""
             t.metadata.pop("AAF", None)
 
-            for c in t.each_child():
+            for c in t.find_children():
                 if hasattr(c, "media_reference") and c.media_reference:
                     mr = c.media_reference
                     mr.metadata.get("AAF", {}).pop('LastModified', None)
@@ -644,7 +644,7 @@ class AAFReaderTests(unittest.TestCase):
                 meta.pop('StartTime', None)
 
             # We don't care about Gap start times, only their duration matters
-            for g in t.each_child(descended_from_type=otio.schema.Gap):
+            for g in t.find_children(descended_from_type=otio.schema.Gap):
                 dur = g.source_range.duration
                 rate = g.source_range.start_time.rate
                 g.source_range = otio.opentime.TimeRange(
@@ -967,7 +967,7 @@ class AAFReaderTests(unittest.TestCase):
         # `Usage_SubClip` value
         subclip_timeline = otio.adapters.read_from_file(SUBCLIP_PATH)
         subclip_usages = {"Subclip.BREATH": "Usage_SubClip"}
-        for clip in subclip_timeline.each_clip():
+        for clip in subclip_timeline.find_clips():
             self.assertEqual(
                 clip.metadata.get("AAF", {}).get("SourceMobUsage"),
                 subclip_usages[clip.name]
@@ -982,7 +982,7 @@ class AAFReaderTests(unittest.TestCase):
             "t-hawk (loop)-HD.mp4": "",
             "tech.fux (loop)-HD.mp4": ""
         }
-        for clip in simple_timeline.each_clip():
+        for clip in simple_timeline.find_clips():
             self.assertEqual(
                 clip.metadata.get("AAF", {}).get("SourceMobUsage", ""),
                 simple_usages[clip.name]
@@ -1203,9 +1203,9 @@ class AAFReaderTests(unittest.TestCase):
 
         all_markers = {}
         for i, track in enumerate(
-                timeline.each_child(descended_from_type=otio.schema.Track)
+                timeline.find_children(descended_from_type=otio.schema.Track)
         ):
-            for item in track.each_child():
+            for item in track.find_children():
                 markers = [
                     (
                         m.name,
@@ -1222,7 +1222,7 @@ class AAFReaderTests(unittest.TestCase):
     def test_keyframed_properties(self):
         def get_expected_dict(timeline):
             expected = []
-            for clip in timeline.each_child(descended_from_type=otio.schema.Clip):
+            for clip in timeline.find_children(descended_from_type=otio.schema.Clip):
                 for effect in clip.effects:
                     props = {}
                     parameters = effect.metadata.get("AAF", {}).get("Parameters", {})
@@ -1568,7 +1568,7 @@ class AAFWriterTests(unittest.TestCase):
         def _target_url_fixup(timeline):
             # fixes up relative paths to be absolute to this test file
             test_dir = os.path.dirname(os.path.abspath(__file__))
-            for clip in timeline.each_clip():
+            for clip in timeline.find_clips():
                 target_url_str = clip.media_reference.target_url
                 clip.media_reference.target_url = os.path.join(test_dir, target_url_str)
 
@@ -1609,7 +1609,7 @@ class AAFWriterTests(unittest.TestCase):
         def _target_url_fixup(timeline):
             # fixes up relative paths to be absolute to this test file
             test_dir = os.path.dirname(os.path.abspath(__file__))
-            for clip in timeline.each_clip():
+            for clip in timeline.find_clips():
                 target_url_str = clip.media_reference.target_url
                 clip.media_reference.target_url = os.path.join(test_dir, target_url_str)
 
@@ -1623,8 +1623,8 @@ class AAFWriterTests(unittest.TestCase):
     def _verify_first_clip(self, original_timeline, aaf_path):
         timeline_from_aaf = otio.adapters.read_from_file(aaf_path)
 
-        original_clips = list(original_timeline.each_clip())
-        aaf_clips = list(timeline_from_aaf.each_clip())
+        original_clips = original_timeline.find_clips()
+        aaf_clips = timeline_from_aaf.find_clips()
 
         self.assertTrue(len(original_clips) > 0)
         self.assertEqual(len(aaf_clips), len(original_clips))
@@ -1719,10 +1719,11 @@ class AAFWriterTests(unittest.TestCase):
                     sequence = opgroup.segments[0]
                 self.assertTrue(isinstance(sequence, Sequence))
 
-                self.assertEqual(len(list(otio_track.each_child(shallow_search=True))),
-                                 len(sequence.components))
+                self.assertEqual(
+                    len(otio_track.find_children(shallow_search=True)),
+                    len(sequence.components))
                 for otio_child, aaf_component in zip(
-                        otio_track.each_child(shallow_search=True),
+                        otio_track.find_children(shallow_search=True),
                         sequence.components):
                     type_mapping = {
                         otio.schema.Clip: aaf2.components.SourceClip,
@@ -1740,7 +1741,7 @@ class AAFWriterTests(unittest.TestCase):
                     if isinstance(aaf_component, aaf2.components.OperationGroup):
                         nested_aaf_segments = aaf_component.segments
                         for nested_otio_child, nested_aaf_segment in zip(
-                                otio_child.each_child(), nested_aaf_segments):
+                                otio_child.find_children(), nested_aaf_segments):
                             self._is_otio_aaf_same(nested_otio_child,
                                                    nested_aaf_segment)
                     else:


### PR DESCRIPTION
This PR removes deprecated Python functions.

Changes ported over from 
https://github.com/AcademySoftwareFoundation/OpenTimelineIO/pull/1437 