### PR TITLE
Update the release pipeline to publish on PyPI using trusted publisher

### DIFF
--- a/.github/workflows/deploy_package.yaml
+++ b/.github/workflows/deploy_package.yaml
@@ -8,24 +8,26 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: '3.x'
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
-        pip install setuptools wheel twine
-    - name: Build and publish
-      env:
-        TWINE_USERNAME: __token__
-        # You need to add a token to your repo's secrets
-        # Make sure you match the name of your secret to the token name below.
-        TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+        python -m pip install build
+    - name: Build dist package
       run: |
-        python setup.py sdist bdist_wheel --universal
-
-        # Make sure everything works on testpypi before releasing on pypi
-        twine upload --repository pypi dist/*
+        python -m build
+    - name: Upload Built Artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: dist
+        path: |
+          ./dist/*.whl
+          ./dist/*.gz
+    - name: Publish package distributions to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Update the release pipeline to publish on PyPI using trusted publisher.