### PR TITLE
Writer: add marker support

### DIFF
--- a/src/otio_aaf_adapter/adapters/aaf_adapter/aaf_writer.py
+++ b/src/otio_aaf_adapter/adapters/aaf_adapter/aaf_writer.py
@@ -6,8 +6,13 @@
 Specifies how to transcribe an OpenTimelineIO file into an AAF file.
 """
 from numbers import Rational
+from pathlib import Path
+from typing import Tuple
+from typing import List
+from typing import Optional
 
 import aaf2
+import aaf2.mobs
 import abc
 import uuid
 import opentimelineio as otio
@@ -16,6 +21,8 @@ import copy
 import re
 import logging
 
+import datetime
+import getpass
 
 AAF_PARAMETERDEF_PAN = aaf2.auid.AUID("e4962322-2267-11d3-8a4c-0050040ef7d2")
 AAF_OPERATIONDEF_MONOAUDIOPAN = aaf2.auid.AUID("9d2ea893-0968-11d3-8a38-0050040ef7d2")
@@ -100,8 +107,9 @@ class AAFFileTranscriber:
         AAFFileTranscriber requires an input timeline and an output pyaaf2 file handle.
 
         Args:
-            input_otio: an input OpenTimelineIO timeline
-            aaf_file: a pyaaf2 file handle to an output file
+            input_otio(otio.schema.Timeline): an input OpenTimelineIO timeline
+            aaf_file(aaf2.file.AAFFile): a pyaaf2 file handle to an output file
+
         """
         self.aaf_file = aaf_file
         self.compositionmob = self.aaf_file.create.CompositionMob()
@@ -362,8 +370,9 @@ class _TrackTranscriber:
         _TrackTranscriber
 
         Args:
-            root_file_transcriber: the corresponding 'parent' AAFFileTranscriber object
-            otio_track: the given otio_track to convert
+            root_file_transcriber(AAFFileTranscriber): the corresponding 'parent'
+                AAFFileTranscriber object
+            otio_track(otio.schema.Track): the given otio_track to convert
         """
         self.root_file_transcriber = root_file_transcriber
         self.compositionmob = root_file_transcriber.compositionmob
@@ -372,6 +381,9 @@ class _TrackTranscriber:
         self.edit_rate = self.otio_track.find_children()[0].duration().rate
         self.timeline_mobslot, self.sequence = self._create_timeline_mobslot()
         self.timeline_mobslot.name = self.otio_track.name
+        self.timeline_mobslot[
+            'PhysicalTrackNumber'
+        ].value = self._aaf_physical_track_number
 
     def transcribe(self, otio_child):
         """Transcribe otio child to corresponding AAF object"""
@@ -396,13 +408,13 @@ class _TrackTranscriber:
 
     @property
     @abc.abstractmethod
-    def media_kind(self):
+    def media_kind(self) -> str:
         """Return the string for what kind of track this is."""
         pass
 
     @property
     @abc.abstractmethod
-    def _master_mob_slot_id(self):
+    def _master_mob_slot_id(self) -> int:
         """
         Return the MasterMob Slot ID for the corresponding track media kind
         """
@@ -413,8 +425,14 @@ class _TrackTranscriber:
         # MasterMob slot 2. While this is a little inadequate, it works for now
         pass
 
+    @property
     @abc.abstractmethod
-    def _create_timeline_mobslot(self):
+    def _aaf_physical_track_number(self) -> int:
+        pass
+
+    @abc.abstractmethod
+    def _create_timeline_mobslot(self) \
+            -> Tuple[aaf2.mobslots.TimelineMobSlot, aaf2.components.Sequence]:
         """
         Return a timeline_mobslot and sequence for this track.
 
@@ -427,11 +445,12 @@ class _TrackTranscriber:
         pass
 
     @abc.abstractmethod
-    def default_descriptor(self, otio_clip):
+    def default_descriptor(self, otio_clip) -> aaf2.essence.EssenceDescriptor:
         pass
 
     @abc.abstractmethod
-    def _transition_parameters(self):
+    def _transition_parameters(self) -> \
+            Tuple[List[aaf2.dictionary.ParameterDef], aaf2.misc.Parameter]:
         pass
 
     def aaf_network_locator(self, otio_external_ref):
@@ -458,8 +477,8 @@ class _TrackTranscriber:
 
         offset = (otio_clip.visible_range().start_time -
                   otio_clip.available_range().start_time)
-        start = offset.value
-        length = otio_clip.visible_range().duration.value
+        start = int(offset.value)
+        length = int(otio_clip.visible_range().duration.value)
 
         compmob_clip = self.compositionmob.create_source_clip(
             slot_id=self.timeline_mobslot.slot_id,
@@ -542,6 +561,134 @@ class _TrackTranscriber:
         transition["CutPoint"].value = otio_transition.metadata["AAF"]["CutPoint"]
         transition["DataDefinition"].value = datadef
         return transition
+
+    def _otio_marker_color_to_aaf_marker_color(self,
+                                               otio_color: Optional[
+                                                   otio.schema.MarkerColor
+                                               ]) -> dict:
+        color_map = {
+            otio.schema.MarkerColor.RED: {
+                "blue": 6564,
+                "green": 12134,
+                "red": 41471
+            },
+            otio.schema.MarkerColor.PINK: {
+                # not in MC, using red instead
+                "blue": 6564,
+                "green": 12134,
+                "red": 41471
+            },
+            otio.schema.MarkerColor.ORANGE: {
+                # not in MC, using red instead
+                "blue": 6564,
+                "green": 12134,
+                "red": 41471
+            },
+            otio.schema.MarkerColor.YELLOW: {
+                "blue": 6553,
+                "green": 58981,
+                "red": 58981
+            },
+            otio.schema.MarkerColor.GREEN: {
+                "blue": 13107,
+                "green": 52428,
+                "red": 13107
+            },
+            otio.schema.MarkerColor.CYAN: {
+                "blue": 52428,
+                "green": 52428,
+                "red": 13107
+            },
+            otio.schema.MarkerColor.BLUE: {
+                "blue": 52428,
+                "green": 13107,
+                "red": 13107
+            },
+            otio.schema.MarkerColor.PURPLE: {
+                # not in MC, using blue instead
+                "blue": 52428,
+                "green": 13107,
+                "red": 13107
+            },
+            otio.schema.MarkerColor.MAGENTA: {
+                "blue": 52428,
+                "green": 13107,
+                "red": 52428
+            },
+            otio.schema.MarkerColor.WHITE: {
+                "blue": 65535,
+                "green": 65535,
+                "red": 65534
+            },
+            otio.schema.MarkerColor.BLACK: {
+                "blue": 0,
+                "green": 0,
+                "red": 0
+            }
+        }
+        return color_map.get(otio_color, color_map[otio.schema.MarkerColor.RED])
+
+    def _transcribe_marker(self,
+                           otio_marker: otio.schema.Marker,
+                           otio_marker_parent: otio.core.Item,
+                           aaf_sequence: aaf2.components.Sequence):
+        username = otio_marker.metadata.get(
+            "AAF", {}
+        ).get("CommentMarkerUser", getpass.getuser())
+
+        color = otio_marker.metadata.get(
+            "AAF", {}
+        ).get("CommentMarkerColor")
+        if not color:
+            color = self._otio_marker_color_to_aaf_marker_color(otio_marker.color)
+
+        transformed_range = otio_marker_parent.transformed_time_range(
+            otio_marker.marked_range, self.otio_track
+        )
+
+        marker = self.aaf_file.create.DescriptiveMarker()
+        # set all possible slots described by markers
+        # FIX: Markers can appear twice in the Avid marker list at the same time
+        marker['DescribedSlots'].value = {1, 2, 3, 4, 10, 11}
+        marker['Position'].value = int(transformed_range.start_time.value)
+        marker['Comment'].value = otio_marker.name
+        marker['CommentMarkerUser'].value = username
+        marker['CommentMarkerColor'].value = color
+
+        # FIX: The datetime doesn't correctly show in MC still
+        time_now = datetime.datetime.now()
+        marker['CommentMarkerTime'].value = time_now.strftime("%H:%M")
+        marker['CommentMarkerDate'].value = time_now.strftime("%m/%d/%Y")
+
+        aaf_sequence.components.append(marker)
+
+    def transcribe_aaf_descriptive_markers(self):
+        otio_markers_parents = {}
+        for otio_marker in self.otio_track.markers:
+            otio_markers_parents[otio_marker] = self.otio_track
+
+        for track_child in self.otio_track.find_children():
+            child_markers = getattr(track_child, "markers", [])
+            for child_marker in child_markers:
+                otio_markers_parents[child_marker] = track_child
+
+        if not otio_markers_parents:
+            return
+
+        event_mob_slot = self.aaf_file.create.EventMobSlot()
+        event_mob_slot['EditRate'].value = self.edit_rate
+        event_mob_slot['SlotID'].value = 1000
+        event_mob_slot[
+            'PhysicalTrackNumber'
+        ].value = self._aaf_physical_track_number
+
+        sequence = self.aaf_file.create.Sequence("DescriptiveMetadata")
+
+        for otio_marker, marker_parent in otio_markers_parents.items():
+            self._transcribe_marker(otio_marker, marker_parent, sequence)
+
+        event_mob_slot.segment = sequence
+        self.compositionmob.slots.append(event_mob_slot)
 
     def aaf_sequence(self, otio_track):
         """Convert an otio Track into an aaf Sequence"""
@@ -660,6 +807,14 @@ class VideoTrackTranscriber(_TrackTranscriber):
     def _master_mob_slot_id(self):
         return 1
 
+    @property
+    def _aaf_physical_track_number(self) -> int:
+        video_tracks = []
+        for track in self.otio_track.parent():
+            if track.kind == otio.schema.TrackKind.Video:
+                video_tracks.append(track)
+        return video_tracks.index(self.otio_track) + 1
+
     def _create_timeline_mobslot(self):
         """
         Create a Sequence container (TimelineMobSlot) and Sequence.
@@ -749,6 +904,14 @@ class AudioTrackTranscriber(_TrackTranscriber):
     @property
     def _master_mob_slot_id(self):
         return 2
+
+    @property
+    def _aaf_physical_track_number(self) -> int:
+        audio_tracks = []
+        for track in self.otio_track.parent():
+            if track.kind == otio.schema.TrackKind.Audio:
+                audio_tracks.append(track)
+        return audio_tracks.index(self.otio_track) + 1
 
     def aaf_sourceclip(self, otio_clip):
         # Parameter Definition

--- a/src/otio_aaf_adapter/adapters/aaf_adapter/aaf_writer.py
+++ b/src/otio_aaf_adapter/adapters/aaf_adapter/aaf_writer.py
@@ -6,7 +6,6 @@
 Specifies how to transcribe an OpenTimelineIO file into an AAF file.
 """
 from numbers import Rational
-from pathlib import Path
 from typing import Tuple
 from typing import List
 from typing import Optional
@@ -490,6 +489,16 @@ class _TrackTranscriber:
         compmob_clip.mob = mastermob
         compmob_clip.slot = mastermob_slot
         compmob_clip.slot_id = mastermob_slot.slot_id
+
+        # check if we need to set mark-in / mark-out
+        if otio_clip.visible_range() != otio_clip.available_range():
+            mastermob_slot["MarkIn"].value = int(
+                otio_clip.visible_range().start_time.value
+            )
+            mastermob_slot["MarkOut"].value = int(
+                otio_clip.visible_range().end_time_exclusive().value
+            )
+
         return compmob_clip
 
     def aaf_transition(self, otio_transition):

--- a/src/otio_aaf_adapter/adapters/aaf_adapter/aaf_writer.py
+++ b/src/otio_aaf_adapter/adapters/aaf_adapter/aaf_writer.py
@@ -15,6 +15,8 @@ from numbers import Rational
 import aaf2
 import aaf2.mobs
 import abc
+import datetime
+import getpass
 import uuid
 import opentimelineio as otio
 import os
@@ -22,7 +24,7 @@ import copy
 import re
 import logging
 
-from typing import Dict, Any
+from typing import Dict, Any, NamedTuple
 
 
 AAF_PARAMETERDEF_PAN = aaf2.auid.AUID("e4962322-2267-11d3-8a4c-0050040ef7d2")
@@ -38,6 +40,96 @@ AAF_VVAL_EXTRAPOLATION_ID = uuid.UUID("0e24dd54-66cd-4f1a-b0a0-670ac3a7a0b3")
 AAF_OPERATIONDEF_SUBMASTER = uuid.UUID("f1db0f3d-8d64-11d3-80df-006008143e6f")
 
 logger = logging.getLogger(__name__)
+
+
+class _MarkerColor(NamedTuple):
+    """An OTIO marker color translated to both of Avids marker color systems.
+
+    Avid stores two color encodings on every marker: a legacy one limited to 8
+    colors (`CommentMarkerColor` / `_ATN_CRM_COLOR`) and a newer extended one with 16
+    colors (`CommentMarkerColorExtended` / `_ATN_CRM_COLOR_EXTENDED`). An extended
+    color that is not one of the 8 legacy colors falls back to a legacy color
+    if required.
+
+    There is five colors (Forest, Denim, Violet, Grey, Gold) exclusive to the Avid
+    so we currently do not handle them in the writer translation.
+    """
+    extended_rgb: Dict[str, int]
+    extended_name: str
+    legacy_rgb: Dict[str, int]
+    legacy_name: str
+
+    @staticmethod
+    def _rgb(red: int, green: int, blue: int) -> Dict[str, int]:
+        return {"red": red, "green": green, "blue": blue}
+
+    @classmethod
+    def for_otio_color(cls, otio_color) -> "_MarkerColor":
+        """Return the Avid marker color for an OTIO marker color, defaulting to red.
+
+        `otio_color` is the value of `marker.color`, which is a name string
+        in OTIO <= 0.18.1 but an `otio.core.Color` object starting with
+        https://github.com/AcademySoftwareFoundation/OpenTimelineIO/pull/2023
+
+        This code is compatible with both color formats.
+        """
+        rgb = cls._rgb
+
+        def legacy(name, r, g, b):
+            # a legacy color is identical in the legacy and extended encoding
+            return cls(rgb(r, g, b), name, rgb(r, g, b), name)
+
+        def extended(name, r, g, b, fallback):
+            # an extended-only color falls back to a legacy color when legacy
+            return cls(rgb(r, g, b), name, fallback.legacy_rgb, fallback.legacy_name)
+
+        red = legacy("Red", 41471, 12134, 6564)
+        green = legacy("Green", 13107, 52428, 13107)
+        blue = legacy("Blue", 13107, 13107, 52428)
+        magenta = legacy("Magenta", 52428, 13107, 52428)
+
+        color_map = {
+            "RED": red,
+            "GREEN": green,
+            "BLUE": blue,
+            "CYAN": legacy("Cyan", 13107, 52428, 52428),
+            "MAGENTA": magenta,
+            "YELLOW": legacy("Yellow", 58981, 58981, 6553),
+            "BLACK": legacy("Black", 0, 0, 0),
+            "WHITE": legacy("White", 65534, 65535, 65535),
+            "PINK": extended("Pink", 61184, 34304, 53504, fallback=magenta),
+            "PURPLE": extended("Purple", 23552, 16128, 62720, fallback=blue),
+            "ORANGE": extended("Orange", 62464, 33024, 12544, fallback=red),
+        }
+
+        if isinstance(otio_color, otio.core.Color):
+            # OTIO >0.18: marker.color is a Color object providing a name
+            name = otio_color.name or ""
+        else:
+            # OTIO<=0.18.1: marker.color is already a name string
+            name = otio_color or ""
+        return color_map.get(name.upper(), red)
+
+
+def _register_marker_extended_color(aaf_file):
+    """Register Avids `CommentMarkerColorExtended` property (no-op if present).
+
+    MC extended (16 color) marker property is not implemented in pyaaf2 yet (as of
+    v1.7.1), so we register the property ourselves. The values were extracted from
+    examples exported from Media Composer.
+    """
+    comment_marker = aaf_file.metadict.lookup_classdef("CommentMarker")
+    for propdef in comment_marker.all_propertydefs():
+        if propdef.name == "CommentMarkerColorExtended":
+            return
+    comment_marker.register_propertydef(
+        "CommentMarkerColorExtended",
+        "e96e6d45-c383-11d3-a069-006094eb75cb",
+        0xffda,
+        "e96e6d43-c383-11d3-a069-006094eb75cb",  # RGBColor record typedef
+        False,
+        False,
+    )
 
 
 def _is_considered_gap(thing):
@@ -113,6 +205,10 @@ class AAFFileTranscriber:
                 assigned that defines the Avid Frame Count Start / End.
         """
         self.aaf_file = aaf_file
+
+        # enable writing Avids extended marker colors
+        _register_marker_extended_color(self.aaf_file)
+
         self.embed_essence = embed_essence
         self.create_edgecode = create_edgecode
         self.compositionmob = self.aaf_file.create.CompositionMob()
@@ -416,6 +512,22 @@ class _TrackTranscriber:
         self.create_edgecode = create_edgecode
         self.timeline_mobslot, self.sequence = self._create_timeline_mobslot()
         self.timeline_mobslot.name = self.otio_track.name
+        self.timeline_mobslot[
+            'PhysicalTrackNumber'
+        ].value = self._aaf_physical_track_number
+
+    @property
+    def _aaf_physical_track_number(self) -> int:
+        """The 1-based index of this track among the tracks of the same kind.
+
+        Markers re-attach on read via (DescribedSlots[0], PhysicalTrackNumber), so
+        the marker EventMobSlot and the picture slot it annotates must share this.
+        """
+        same_kind = [
+            track for track in self.otio_track.parent()
+            if track.kind == self.otio_track.kind
+        ]
+        return same_kind.index(self.otio_track) + 1
 
     def transcribe(self, otio_child):
         """Transcribe otio child to corresponding AAF object"""
@@ -737,6 +849,147 @@ class _TrackTranscriber:
             sequence.components.append(result)
         sequence.length = length
         return sequence
+
+    def _transcribe_marker(self,
+                           otio_marker: otio.schema.Marker,
+                           otio_marker_parent: otio.core.Item
+                           ) -> aaf2.components.DescriptiveMarker:
+        marker_metadata = otio_marker.metadata.get("AAF", {})
+        prev_attrs = marker_metadata.get("CommentMarkerAttributeList", {})
+        prev_comments = marker_metadata.get("UserComments", {})
+
+        # NOTE: Avid misspelled the user property as "CommentMarkerUSer",
+        # which is the key the reader produces, so we keep that typo.
+        username = (
+            marker_metadata.get("CommentMarkerUSer")
+            or prev_attrs.get("_ATN_CRM_USER")
+            or getpass.getuser()
+        )
+
+        # grab marker color from OTIO marker object
+        marker_color = _MarkerColor.for_otio_color(otio_marker.color)
+
+        # MC reads the marker date from the Int32 unix timestamps below, NOT
+        # from the CommentMarkerTime / CommentMarkerDate strings. We set the strings
+        # anyway for legibility (and other tools may read them?). Preserve all of them
+        # on round-trip, falling back to "now" for new markers.
+        time_now = datetime.datetime.now()
+        create_date = int(
+            prev_attrs.get("_ATN_CRM_LONG_CREATE_DATE") or time_now.timestamp()
+        )
+        mod_date = int(prev_attrs.get("_ATN_CRM_LONG_MOD_DATE") or create_date)
+        date_str = (
+            marker_metadata.get("CommentMarkerDate")
+            or prev_attrs.get("_ATN_CRM_DATE")
+            or time_now.strftime("%m/%d/%Y")
+        )
+        time_str = (
+            marker_metadata.get("CommentMarkerTime")
+            or prev_attrs.get("_ATN_CRM_TIME")
+            or time_now.strftime("%H:%M")
+        )
+
+        range_in_track = otio_marker_parent.transformed_time_range(
+            otio_marker.marked_range, self.otio_track
+        )
+
+        aaf_marker = self.aaf_file.create.DescriptiveMarker()
+
+        # A marker in MC is a point event and seemingly does not care about Length.
+        # However, pyaaf2 (1.7.0) currently initializes the Length property to 0.
+        # The OTIO AAF reader reads that value to determine the marker length
+        # (defaults to 1), so we want to set the marker length anyway,
+        # to enable proper round trips.
+        aaf_marker['Length'].value = int(otio_marker.marked_range.duration.value)
+
+        # DescribedSlots points at the picture slot this marker annotates.
+        # Media Composer only reads the first entry, and the marker is re-attached
+        # on read via (DescribedSlots[0], EventMobSlot.PhysicalTrackNumber), so this
+        # must be the timeline slot id of the track being transcribed.
+        aaf_marker['DescribedSlots'].value = {int(self.timeline_mobslot.slot_id)}
+
+        aaf_marker['Position'].value = int(range_in_track.start_time.value)
+        aaf_marker['Comment'].value = otio_marker.name
+        aaf_marker['CommentMarkerUser'].value = username
+        aaf_marker['CommentMarkerColor'].value = marker_color.legacy_rgb
+        aaf_marker['CommentMarkerColorExtended'].value = marker_color.extended_rgb
+        aaf_marker['CommentMarkerTime'].value = time_str
+        aaf_marker['CommentMarkerDate'].value = date_str
+
+        # Mirror everything we can into the marker attribute list.
+        # MC displays some of these values only in the Marker window.
+        attr_list = aaf2.misc.TaggedValueHelper(
+            aaf_marker['CommentMarkerAttributeList']
+        )
+        attr_list["_ATN_CRM_COM"] = otio_marker.name
+        attr_list["_ATN_CRM_USER"] = username
+        attr_list["_ATN_CRM_DATE"] = date_str
+        attr_list["_ATN_CRM_TIME"] = time_str
+        attr_list["_ATN_CRM_COLOR"] = marker_color.legacy_name
+        attr_list["_ATN_CRM_COLOR_EXTENDED"] = marker_color.extended_name
+        attr_list["_ATN_CRM_MARKNAME"] = otio_marker.name
+        attr_list["_ATN_CRM_LONG_CREATE_DATE"] = create_date
+        attr_list["_ATN_CRM_LONG_MOD_DATE"] = mod_date
+
+        # UserComments mirror what Avid round-trips for the marker UI. DatabaseID /
+        # _ATN_CRM_ID is an MC internal IDs, we dont create them if they are not there.
+        database_id = prev_comments.get("DatabaseID") or prev_attrs.get("_ATN_CRM_ID")
+        if database_id:
+            attr_list["_ATN_CRM_ID"] = database_id
+        user_comments = aaf2.misc.TaggedValueHelper(aaf_marker['UserComments'])
+        user_comments["Comment"] = otio_marker.name
+        if database_id:
+            user_comments["DatabaseID"] = database_id
+
+        return aaf_marker
+
+    def transcribe_aaf_descriptive_markers(self):
+        """Transcribe all OTIO markers on the track onto one EventMobSlot which we
+        append to the composition mob.
+        """
+        # collect all OTIO marker parents on the track
+        otio_markers_parents = {}
+        for otio_marker in self.otio_track.markers:
+            otio_markers_parents[otio_marker] = self.otio_track
+
+        for track_child in self.otio_track.find_children():
+            child_markers = getattr(track_child, "markers", [])
+            for child_marker in child_markers:
+                otio_markers_parents[child_marker] = track_child
+
+        if not otio_markers_parents:
+            return
+
+        # Create a mob to hold the markers. MC needs one EventMobSlot per marked track,
+        # so we start with a high SlotID (1000+) that doesn't collide with the
+        # other slots on the composition mob.
+        event_mob_slot = self.aaf_file.create.EventMobSlot()
+        event_mob_slot['EditRate'].value = self.edit_rate
+
+        existing_slot_ids = {slot.slot_id for slot in self.compositionmob.slots}
+        event_slot_id = 1000
+        while event_slot_id in existing_slot_ids:
+            event_slot_id += 1
+        event_mob_slot['SlotID'].value = event_slot_id
+
+        # attaches the markers to the right track
+        event_mob_slot[
+            'PhysicalTrackNumber'
+        ].value = self._aaf_physical_track_number
+
+        # create a sequence with all markers for the track
+        sequence = self.aaf_file.create.Sequence("DescriptiveMetadata")
+        markers = [
+            self._transcribe_marker(otio_marker, marker_parent)
+            for otio_marker, marker_parent in otio_markers_parents.items()
+        ]
+
+        # Markers on an EventMobSlot should be sorted by increasing position.
+        for marker in sorted(markers, key=lambda m: m['Position'].value):
+            sequence.components.append(marker)
+
+        event_mob_slot.segment = sequence
+        self.compositionmob.slots.append(event_mob_slot)
 
     def aaf_operation_group(self, otio_stack):
         """

--- a/src/otio_aaf_adapter/adapters/advanced_authoring_format.py
+++ b/src/otio_aaf_adapter/adapters/advanced_authoring_format.py
@@ -686,7 +686,7 @@ def _transcribe(item, parents, edit_rate, indent=0):
 
             event_mob = event_mobs[-1]
 
-            metadata["AttachedSlotID"] = int(metadata["DescribedSlots"][0])
+            metadata["AttachedSlotIds"] = [int(x) for x in metadata["DescribedSlots"]]
             metadata["AttachedPhysicalTrackNumber"] = int(
                 event_mob["PhysicalTrackNumber"].value
             )
@@ -1248,7 +1248,6 @@ def _attach_markers(collection):
             track_number = metadata.get("PhysicalTrackNumber")
             if slot_id is None or track_number is None:
                 continue
-
             tracks_map[(int(slot_id), int(track_number))] = track
 
         # iterate all tracks for their markers and attach them to the matching item
@@ -1256,9 +1255,14 @@ def _attach_markers(collection):
                 descended_from_type=otio.schema.Track):
             for marker in list(current_track.markers):
                 metadata = marker.metadata.get("AAF", {})
-                slot_id = metadata.get("AttachedSlotID")
+                attached_slot_ids = metadata.get("AttachedSlotIds", [])
+
                 track_number = metadata.get("AttachedPhysicalTrackNumber")
-                target_track = tracks_map.get((slot_id, track_number))
+                target_track = None
+                for slot_id in attached_slot_ids:
+                    target_track = tracks_map.get((slot_id, track_number))
+                    if target_track:
+                        break
 
                 # remove marker from current parent track
                 current_track.markers.remove(marker)

--- a/src/otio_aaf_adapter/adapters/advanced_authoring_format.py
+++ b/src/otio_aaf_adapter/adapters/advanced_authoring_format.py
@@ -931,10 +931,16 @@ def _transcribe(item, parents, edit_rate, indent=0):
                 event_mob["PhysicalTrackNumber"].value
             )
 
-            # determine marker color
+            # determine marker color, prefer new extended color attribute
+            # if not set, read legacy attribute instead
+            marker_attributes = metadata.get("CommentMarkerAttributeList", {})
             color = _marker_color_from_string(
-                metadata.get("CommentMarkerAttributeList", {}).get("_ATN_CRM_COLOR")
+                marker_attributes.get("_ATN_CRM_COLOR_EXTENDED")
             )
+            if color is None:
+                color = _marker_color_from_string(
+                    marker_attributes.get("_ATN_CRM_COLOR")
+                )
             if color is None:
                 color = _convert_rgb_to_marker_color(
                     metadata.get("CommentMarkerColor")
@@ -2010,6 +2016,9 @@ def write_to_file(
                 result = transcriber.transcribe(otio_child)
                 if result:
                     transcriber.sequence.components.append(result)
+
+            # transcribe markers on the track (or its children)
+            transcriber.transcribe_aaf_descriptive_markers()
 
         # Always add a timecode track to the main composition mob.
         # This is required for compatibility with DaVinci Resolve.

--- a/tests/test_aaf_adapter.py
+++ b/tests/test_aaf_adapter.py
@@ -1469,38 +1469,37 @@ class AAFReaderTests(unittest.TestCase):
         timeline = otio.adapters.read_from_file(MULTIPLE_MARKERS_PATH,
                                                 attach_markers=True)
 
-        Color = otio.schema.MarkerColor
         expected_markers = {
-            (0, 'Filler'): [('PUBLISH', 0.0, 1.0, 24.0, Color.RED)],
+            (0, 'Filler'): [('PUBLISH', 0.0, 1.0, 24.0, 'RED')],
             (0, 'zts02_1010'): [
                 ('GREEN: V1: zts02_1010: f1104: seq.f1104',
-                 1104.0, 1.0, 24.0, Color.GREEN)
+                 1104.0, 1.0, 24.0, 'GREEN')
             ],
             (1, 'ScopeReference'): [
-                ('FX', 0.0, 1.0, 24.0, Color.YELLOW),
+                ('FX', 0.0, 1.0, 24.0, 'YELLOW'),
                 ('BLUE: V2 (no FX): zts02_1020: f1134: seq.f1327',
-                 518.0, 1.0, 24.0, Color.BLUE)
+                 518.0, 1.0, 24.0, 'BLUE')
             ],
             (2, 'ScopeReference'): [
-                ('INSERT', 0.0, 1.0, 24.0, Color.CYAN),
+                ('INSERT', 0.0, 1.0, 24.0, 'CYAN'),
                 ('CYAN: V3: zts02_1030: f1212: seq.f1665',
                  856.0,
                  1.0,
                  24.0,
-                 Color.CYAN)
+                 'CYAN')
             ],
             (3, 'Drop_24.mov'): [
                 ('MAGENTA: V4: zts02_1040: f1001: seq.f1666',
-                 86400.0, 1.0, 24.0, Color.MAGENTA)
+                 86400.0, 1.0, 24.0, 'MAGENTA')
             ],
             (3, 'Flow_07.mov'): [('GREEN: TC1: zts02_1080: f1206: seq.f2604',
                                   -207.0,  # this marker should probably discarded?
                                   1.0,
                                   24.0,
-                                  Color.GREEN)],
+                                  'GREEN')],
             (4, 'ScopeReference'): [
                 ('RED: V5: zts02_1050: f1061: seq.f1885',
-                 884.0, 1.0, 24.0, Color.RED)
+                 884.0, 1.0, 24.0, 'RED')
             ]
         }
 

--- a/tests/test_aaf_adapter.py
+++ b/tests/test_aaf_adapter.py
@@ -1515,7 +1515,14 @@ class AAFReaderTests(unittest.TestCase):
                         m.marked_range.start_time.value,
                         m.marked_range.duration.value,
                         m.marked_range.start_time.rate,
-                        m.color
+
+                        # marker.color is an upper-case name string in
+                        # OTIO <= 0.18.1 and a title-case formatted name string
+                        # starting with
+                        # https://github.com/AcademySoftwareFoundation/OpenTimelineIO/pull/2023
+                        # Compare on the upper-cased name so the test works for both
+                        m.color.name.upper() if isinstance(m.color, otio.core.Color)
+                        else m.color
                     ) for m in item.markers
                 ]
                 if markers:
@@ -2907,6 +2914,107 @@ class AAFWriterTests(unittest.TestCase):
 
                 for key, val in expected_attr_values[i].items():
                     self.assertEqual(helper[key], val)
+
+    def test_aaf_writer_marker_roundtrip(self):
+        """Markers survive write -> read AAF round-trip.
+        """
+        clip_fps = 24
+        clip_dur = otio.opentime.RationalTime(100, clip_fps)
+
+        def _clip(name, marked_frame, color):
+            range = otio.opentime.TimeRange(
+                otio.opentime.RationalTime(0, clip_fps), clip_dur
+            )
+            clip = otio.schema.Clip(
+                name=name,
+                source_range=range,
+                media_reference=otio.schema.ExternalReference(available_range=range),
+            )
+            if marked_frame is not None:
+                clip.markers.append(otio.schema.Marker(
+                    name=f"note on {name}",
+                    color=color,
+                    marked_range=otio.opentime.TimeRange(
+                        start_time=otio.opentime.RationalTime(marked_frame, clip_fps),
+                        duration=otio.opentime.RationalTime(1, clip_fps),
+                    ),
+                ))
+            return clip
+
+        # two video tracks, markers on V1 clip[1] and V2 clip[0], one clip unmarked.
+        timeline = otio.schema.Timeline()
+        timeline.tracks.append(otio.schema.Track(children=[
+            _clip("V1-a", None, None),
+            _clip("V1-b", 5, otio.schema.MarkerColor.PINK),
+        ]))
+        timeline.tracks.append(otio.schema.Track(children=[
+            _clip("V2-a", 10, otio.schema.MarkerColor.PURPLE),
+            _clip("V2-b", None, None),
+        ]))
+
+        _, tmp_aaf_path = tempfile.mkstemp(suffix='.aaf')
+        otio.adapters.write_to_file(timeline, tmp_aaf_path, use_empty_mob_ids=True)
+        result = otio.adapters.read_from_file(tmp_aaf_path)
+
+        markers_by_clip = {
+            clip.name: clip.markers
+            for clip in result.find_clips() if clip.markers
+        }
+
+        # only the two marked clips carry a marker
+        self.assertEqual(set(markers_by_clip), {"V1-b", "V2-a"})
+
+        expected = {
+            "V1-b": ("note on V1-b", otio.schema.MarkerColor.PINK, 5),
+            "V2-a": ("note on V2-a", otio.schema.MarkerColor.PURPLE, 10),
+        }
+
+        # parameterize the subtests to make it easier to see which clip fails
+        for clip_name, (name, color, frame) in expected.items():
+            with self.subTest(clip=clip_name):
+                self.assertEqual(len(markers_by_clip[clip_name]), 1)
+                marker = markers_by_clip[clip_name][0]
+
+                self.assertEqual(marker.name, name)
+                self.assertEqual(marker.color, color)
+
+                # markers are a single frame and keep their position
+                self.assertEqual(
+                    marker.marked_range.start_time,
+                    otio.opentime.RationalTime(frame, clip_fps),
+                )
+
+                self.assertEqual(
+                    marker.marked_range.duration,
+                    otio.opentime.RationalTime(1, clip_fps),
+                )
+
+        # Check if attributes are correctly translated into AAF
+        with aaf2.open(tmp_aaf_path) as aaf_file:
+            markers = [
+                comp
+                for mob in aaf_file.content.mobs
+                for slot in mob.slots
+                if isinstance(slot, aaf2.mobslots.EventMobSlot)
+                for comp in slot.segment.components
+            ]
+            self.assertEqual(len(markers), 2)
+
+            # extended name -> legacy fallback name, for the colors used above
+            legacy_fallback = {"Pink": "Magenta", "Purple": "Blue"}
+
+            for marker in markers:
+                attrs = {tv.name: tv.value
+                         for tv in marker["CommentMarkerAttributeList"].value}
+                self.assertGreater(attrs["_ATN_CRM_LONG_CREATE_DATE"], 0)
+                self.assertGreater(attrs["_ATN_CRM_LONG_MOD_DATE"], 0)
+                self.assertEqual(attrs["_ATN_CRM_MARKNAME"], marker["Comment"].value)
+                extended_name = attrs["_ATN_CRM_COLOR_EXTENDED"]
+                self.assertIn(extended_name, legacy_fallback)
+                self.assertEqual(
+                    attrs["_ATN_CRM_COLOR"], legacy_fallback[extended_name]
+                )
+                self.assertIsNotNone(marker["CommentMarkerColorExtended"].value)
 
 
 class SimplifyTests(unittest.TestCase):


### PR DESCRIPTION
### Requires

Stacked PR on top of #71. 

### Summary

This change adds initial write support for markers. This includes all relevant marker information displayed in the Media Composer marker window:

- Name
- Comment
- User
- Creation Date
- Color

Markers are able to be round-tripped successfully and the adapter supports all colors which have an OTIO equivalent. Some of the more exotic Avid colors like Forest and Denim are remapped to more portable colors for now.

### Suggestion omitted

There was some discussion about having the marker being a truly point based event with zero duration (see https://github.com/OpenTimelineIO/otio-aaf-adapter/pull/44#issuecomment-3110210614). Since I tried to have no impact on the reader behaviour with this initial PR, we should make that change in another PR and release it separately. It's a moderate change, but unlike this PR, it would change the adapter output somewhat.

**Reference associated tests.**

- `tests/test_aaf_adapter.py`

Assisted-by: Claude:claude-opus-4-8 [code-review] [debugging]