### PR TITLE
Post 0.17.0 Release

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,13 +64,11 @@ jobs:
       plugin_name: "otio_aaf_plugin"
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        # Use macos-13 so we'll be on intel hardware and can pull a pre-built wheel
+        # When OTIO has an Apple Silicon build we can switch back to macos-latest for that version
+        os: [ubuntu-latest, macos-13, windows-latest]
         otio-version: ["main", "0.17.0"]
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
-        exclude:
-          - { os: macos-latest, python-version: 3.7 }
-          - { os: macos-latest, python-version: 3.8 }
-          - { os: macos-latest, python-version: 3.9 }
 
     name: ${{ matrix.os }} py-${{ matrix.python-version }} otio-${{ matrix.otio-version }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,6 +67,10 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
         otio-version: ["main", "0.17.0"]
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        exclude:
+          - { os: macos-latest, python-version: 3.7 }
+          - { os: macos-latest, python-version: 3.8 }
+          - { os: macos-latest, python-version: 3.9 }
 
     name: ${{ matrix.os }} py-${{ matrix.python-version }} otio-${{ matrix.otio-version }}
     runs-on: ${{ matrix.os }}
@@ -93,7 +97,7 @@ jobs:
         if [[ "${{ matrix.otio-version }}" == "main" ]]; then
           pip install "git+https://github.com/AcademySoftwareFoundation/OpenTimelineIO.git@extract_adapters"
         else
-          pip install OpenTimelineIO>=${{ matrix.otio-version }} --pre --only-binary :all:
+          pip install OpenTimelineIO>=${{ matrix.otio-version }} --only-binary :all:
         fi
 
     - name: Run Unit Tests

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -93,7 +93,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install pytest pytest-cov wheel -V pyaaf2
         if [[ "${{ matrix.otio-version }}" == "main" ]]; then
-          pip install "git+https://github.com/AcademySoftwareFoundation/OpenTimelineIO.git@extract_adapters"
+          pip install "git+https://github.com/AcademySoftwareFoundation/OpenTimelineIO.git"
         else
           pip install OpenTimelineIO>=${{ matrix.otio-version }} --only-binary :all:
         fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "otio-aaf-adapter"
-version = "1.1.0.dev1"
+version = "1.1.0"
 description = "OpenTimelineIO AAF Adapter"
 authors = [
   { name="Contributors to the OpenTimelineIO project", email="otio-discussion@lists.aswf.io" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ license = { file="LICENSE.txt" }
 readme = "README.md"
 requires-python = ">=3.7"
 dependencies = [
-    "opentimelineio >= 0.17.0.dev1",
+    "opentimelineio >= 0.17.0",
     "pyaaf2>=1.4.0"
 ]
 


### PR DESCRIPTION
Prep for 0.17.0 release
Removed `--pre` flag, set dependency to 0.17.0 and added exclusion of old python versions for macos-latest

**Expected to fail in CI until 0.17.0 is out**