### PR TITLE
Loft arguments out of kwargs

### DIFF
--- a/src/otio_aaf_adapter/adapters/advanced_authoring_format.py
+++ b/src/otio_aaf_adapter/adapters/advanced_authoring_format.py
@@ -1641,8 +1641,6 @@ def read_from_file(
 def write_to_file(
     input_otio,
     filepath,
-    # lofting these options out of the aaf writer to make them visible in the
-    # `otiopluginfo` output.
     prefer_file_mob_id=False,
     use_empty_mob_ids=False,
     **kwargs

--- a/src/otio_aaf_adapter/adapters/advanced_authoring_format.py
+++ b/src/otio_aaf_adapter/adapters/advanced_authoring_format.py
@@ -1638,7 +1638,15 @@ def read_from_file(
     return result
 
 
-def write_to_file(input_otio, filepath, **kwargs):
+def write_to_file(
+    input_otio,
+    filepath,
+    # lofting these options out of the aaf writer to make them visible in the
+    # `otiopluginfo` output.
+    prefer_file_mob_id=False,
+    use_empty_mob_ids=False,
+    **kwargs
+):
 
     with aaf2.open(filepath, "w") as f:
 
@@ -1646,7 +1654,13 @@ def write_to_file(input_otio, filepath, **kwargs):
 
         aaf_writer.validate_metadata(timeline)
 
-        otio2aaf = aaf_writer.AAFFileTranscriber(timeline, f, **kwargs)
+        otio2aaf = aaf_writer.AAFFileTranscriber(
+            timeline,
+            f,
+            prefer_file_mob_id=prefer_file_mob_id,
+            use_empty_mob_ids=use_empty_mob_ids,
+            **kwargs
+        )
 
         if not isinstance(timeline, otio.schema.Timeline):
             raise otio.exceptions.NotSupportedError(


### PR DESCRIPTION
* Lofting the arguments out of kwargs and into the function signatures makes it easier to discover what controls are available to the adapter
* because `otiopluginfo` uses reflection to discover arguments, non-kwargs arguments will show up in the output of `otiopluginfo` if they are lofted out:

```
❯ otiopluginfo AAF -p adapters
Manifests loaded:
  ~/workspace/otio-aaf-adapter/src/otio_aaf_adapter/plugin_manifest.json
  ~/opt/miniconda3/envs/otio.test.py38/lib/python3.8/site-packages/opentimelineio/adapters/builtin_adapters.plugin_manifest.json

adapters:
  AAF
    doc (short): OpenTimelineIO Advanced Authoring Format (AAF) Adapter
    path: ~/Documents/workspace/otio-aaf-adapter/src/otio_aaf_adapter/adapters/advanced_authoring_format.py
    from manifest: ~/Documents/workspace/otio-aaf-adapter/src/otio_aaf_adapter/plugin_manifest.json
    explicit supported features:
      read_from_file args: ['filepath', 'simplify', 'transcribe_log', 'attach_markers', 'bake_keyframed_properties']
      write_to_file args: ['input_otio', 'filepath', 'prefer_file_mob_id', 'use_empty_mob_ids']
```