### PR TITLE
Fix NTSC rates in global start time test

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -75,7 +75,6 @@ jobs:
           - { os: macos-latest, shell: bash }
           - { os: macos-13, shell: bash }
           - { os: windows-latest, shell: pwsh }
-          - { os: windows-latest, shell: msys2, python-version: 'mingw64' }
         exclude:
           - { os: macos-latest, python-version: 3.7 }
           - { os: macos-latest, python-version: 3.8 }

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -66,9 +66,21 @@ jobs:
       matrix:
         # Use macos-13 so we'll be on intel hardware and can pull a pre-built wheel
         # When OTIO has an Apple Silicon build we can switch back to macos-latest for that version
-        os: [ubuntu-latest, macos-13, windows-latest]
+        os: [ubuntu-latest, macos-13, windows-latest, macos-latest]
         otio-version: ["main", "0.17.0"]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        include:
+          - { os: ubuntu-latest, shell: bash }
+          - { os: ubuntu-22.04, shell: bash, python-version: 3.7 }
+          - { os: macos-latest, shell: bash }
+          - { os: macos-13, shell: bash }
+          - { os: windows-latest, shell: pwsh }
+          - { os: windows-latest, shell: msys2, python-version: 'mingw64' }
+        exclude:
+          - { os: macos-latest, python-version: 3.7 }
+          - { os: macos-latest, python-version: 3.8 }
+          - { os: macos-latest, python-version: 3.9 }
+          - { os: ubuntu-latest, python-version: 3.7 }
 
     name: ${{ matrix.os }} py-${{ matrix.python-version }} otio-${{ matrix.otio-version }}
     runs-on: ${{ matrix.os }}

--- a/tests/test_aaf_adapter.py
+++ b/tests/test_aaf_adapter.py
@@ -1931,12 +1931,12 @@ class AAFWriterTests(unittest.TestCase):
                          expected)
 
     def test_aaf_writer_global_start_time(self):
-        for tc, rate in [("01:00:00:00", 23.97),
+        for tc, rate in [("01:00:00:00", 24000 / 1001),
                          ("01:00:00:00", 24),
                          ("01:00:00:00", 25),
-                         ("01:00:00:00", 29.97),
+                         ("01:00:00:00", 30000 / 1001),
                          ("01:00:00:00", 30),
-                         ("01:00:00:00", 59.94),
+                         ("01:00:00:00", 60000 / 1001),
                          ("01:00:00:00", 60)]:
 
             otio_timeline = otio.schema.Timeline()


### PR DESCRIPTION
This PR fixes the AAF adapter tests to work with the updated handling of NTSC timecode rates from this OTIO PR: https://github.com/AcademySoftwareFoundation/OpenTimelineIO/pull/1477

Without this change, the AAF adapter tests fail against current OTIO.

This PR also updates the CI matrix to (mostly) match the core OTIO repo's CI, working around an issue with specific Python versions not existing for some OS-latest versions.
