### PR TITLE
Upgraded `upload-artifact` to v4, due to v3 being deprecated.

### DIFF
--- a/.github/workflows/deploy_package.yaml
+++ b/.github/workflows/deploy_package.yaml
@@ -23,7 +23,7 @@ jobs:
       run: |
         python -m build
     - name: Upload Built Artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: dist
         path: |


### PR DESCRIPTION
Upgraded `upload-artifact` to v4, due to v3 being deprecated.

See https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/