### PR TITLE
Update requirements to use OTIO >=0.18, Python >3.9.0, drop Intel from CI matrix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,15 +64,12 @@ jobs:
       plugin_name: "otio_aaf_plugin"
     strategy:
       matrix:
-        # Use macos-13 so we'll be on intel hardware and can pull a pre-built wheel
-        # When OTIO has an Apple Silicon build we can switch back to macos-latest for that version
-        os: [ubuntu-latest, macos-13, windows-latest, macos-latest]
-        otio-version: ["main", "0.17.0"]
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        otio-version: ["main", "0.18.1"]
         python-version: [ "3.9", "3.10", "3.11", "3.12"]
         include:
           - { os: ubuntu-latest, shell: bash }
           - { os: macos-latest, shell: bash }
-          - { os: macos-13, shell: bash }
           - { os: windows-latest, shell: pwsh }
         exclude:
           - { os: macos-latest, python-version: 3.9 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,9 +13,9 @@ authors = [
 ]
 license = { file="LICENSE.txt" }
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">3.9.0"
 dependencies = [
-    "opentimelineio >= 0.17.0",
+    "opentimelineio >= 0.18.0",
     "pyaaf2>=1.7.0"
 ]
 


### PR DESCRIPTION
Updates adapter to use the latest OTIO minor release, so `otio.core.Color` becomes available for other PRs. 
This also introduces the new `>3.9.0` baseline enforced by the main library.

macOS 13 runners have been retired by Github and since this is a Python only package, it's a good opportunity to simplify the Matrix and have just one macOS runner on Apple Silicon instead. The wheel will still be compatible with Intel Macs.