### PR TITLE
Fix wrong hook constants in read transcribe hooks and add read hook test

### DIFF
--- a/src/otio_aaf_adapter/adapters/aaf_adapter/hooks.py
+++ b/src/otio_aaf_adapter/adapters/aaf_adapter/hooks.py
@@ -59,7 +59,7 @@ def run_pre_read_transcribe_hook(
     to OTIO data. It can be useful to manipulate the AAF data directly before the
     transcribing occurs. The hook doesn't return a timeline, since it runs before the
     Timeline object has been transcribed."""
-    if HOOK_PRE_WRITE_TRANSCRIBE in otio.hooks.names():
+    if HOOK_PRE_READ_TRANSCRIBE in otio.hooks.names():
         extra_kwargs.update({
             "read_filepath": read_filepath,
             "aaf_handle": aaf_handle,
@@ -77,12 +77,12 @@ def run_post_read_transcribe_hook(
     but before it is simplified. Possible use cases could be logic to extract and
     transcode media from the AAF.
     """
-    if HOOK_POST_WRITE_TRANSCRIBE in otio.hooks.names():
+    if HOOK_POST_READ_TRANSCRIBE in otio.hooks.names():
         extra_kwargs.update({
             "read_filepath": read_filepath,
             "aaf_handle": aaf_handle
         })
-        return otio.hooks.run(HOOK_POST_WRITE_TRANSCRIBE,
+        return otio.hooks.run(HOOK_POST_READ_TRANSCRIBE,
                               tl=timeline,
                               extra_args=extra_kwargs)
     return timeline

--- a/tests/test_aaf_adapter.py
+++ b/tests/test_aaf_adapter.py
@@ -2525,7 +2525,7 @@ class AAFWriterTests(unittest.TestCase):
                     otio.plugins.plugin_info_map()["hooks"]
                 )
 
-    def test_transcribe_hook_args_map(self):
+    def test_transcribe_write_hook_args_map(self):
         """Tests if extra arguments are correctly passed to the hooks.
         """
 
@@ -2550,6 +2550,26 @@ class AAFWriterTests(unittest.TestCase):
                         filepath=tmp_aaf_path,
                         embed_essence=True,
                         use_empty_mob_ids=True,
+                        hook_function_argument_map={
+                            "test_post_hook_raise": True
+                        }
+                    )
+
+    def test_transcribe_read_hook_args_map(self):
+        """Tests if extra arguments are correctly passed to the read hooks."""
+        if otio.adapters.from_name("AAF").has_feature("hooks"):
+            with with_hooks_plugin_environment():
+                with self.assertRaises(AAFAdapterError):
+                    otio.adapters.read_from_file(
+                        SIMPLE_EXAMPLE_PATH,
+                        hook_function_argument_map={
+                            "test_pre_hook_raise": True
+                        }
+                    )
+
+                with self.assertRaises(AAFAdapterError):
+                    otio.adapters.read_from_file(
+                        SIMPLE_EXAMPLE_PATH,
                         hook_function_argument_map={
                             "test_post_hook_raise": True
                         }


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**

N/A — found while trying to use the hooks and reviewing the hooks module.

**Summarize your change.**

`run_pre_read_transcribe_hook` and `run_post_read_transcribe_hook` in `hooks.py` were using `HOOK_PRE_WRITE_TRANSCRIBE` / `HOOK_POST_WRITE_TRANSCRIBE` instead of their READ counterparts. This meant the read hooks would never fire correctly.

Changes:
- Fixed the condition in `run_pre_read_transcribe_hook`
- Fixed the condition and `otio.hooks.run` call in `run_post_read_transcribe_hook`
- Renamed `test_transcribe_hook_args_map` to `test_transcribe_write_hook_args_map` for clarity
- Added `test_transcribe_read_hook_args_map` to cover the read hook path

**Reference associated tests.**

- `test_transcribe_read_hook_args_map` — new test that validates both pre and post read hooks fire correctly using the existing `hooks_plugin_example` plugin
- `test_transcribe_write_hook_args_map` — existing test (renamed), still covers the write path
- `test_transcribe_hooks_registry` — existing test, unchanged
