### PR TITLE
CI: Fix Windows builds

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,13 +64,18 @@ jobs:
       plugin_name: "otio_aaf_plugin"
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-15]
+        # Pinned to windows-2022 because the June 2026 migration of
+        # windows-latest to Windows Server 2025 + Visual Studio 2026 +
+        # CMake 4.3 breaks the vcpkg-based ZLIB find_package path.
+        # windows-2022 is supported by GitHub through ~2028.
+        # See: https://github.com/AcademySoftwareFoundation/OpenTimelineIO/pull/2021
+        os: [ubuntu-latest, windows-2022, macos-15]
         otio-version: ["main", "0.18.1"]
         python-version: [ "3.9", "3.10", "3.11", "3.12"]
         include:
           - { os: ubuntu-latest, shell: bash }
           - { os: macos-15, shell: bash }
-          - { os: windows-latest, shell: pwsh }
+          - { os: windows-2022, shell: pwsh }
         exclude:
           - { os: macos-15, python-version: 3.9 }
 
@@ -91,6 +96,18 @@ jobs:
         name: wheel
         path: dist/
 
+    # OTIO main builds from source and it requires ZLIB, which the vanilla Windows
+    # runners currently do not provide. Install via vcpkg and expose it. Only the
+    # 'main' path builds from source. Released OTIO versions install from wheel.
+    # See: https://github.com/AcademySoftwareFoundation/OpenTimelineIO/pull/2021
+    - name: Install ZLIB (Windows)
+      if: runner.os == 'Windows' && matrix.otio-version == 'main'
+      shell: pwsh
+      run: |
+        vcpkg install zlib:x64-windows
+        echo "CMAKE_PREFIX_PATH=C:/vcpkg/installed/x64-windows" >> $env:GITHUB_ENV
+        echo "C:/vcpkg/installed/x64-windows/bin" >> $env:GITHUB_PATH
+
     - name: Install dependencies
       shell: bash
       run: |
@@ -101,6 +118,22 @@ jobs:
         else
           pip install OpenTimelineIO>=${{ matrix.otio-version }} --only-binary :all:
         fi
+
+    # Python 3.8+ no longer searches PATH for a C-extensions dependent DLLs,
+    # so the vcpkg zlib runtime DLL must sit next to the compiled _otio.pyd.
+    # See: https://github.com/AcademySoftwareFoundation/OpenTimelineIO/pull/2021
+    - name: Copy ZLIB DLL next to _otio.pyd (Windows)
+      if: runner.os == 'Windows' && matrix.otio-version == 'main'
+      shell: pwsh
+      run: |
+        $target = python -c "import sysconfig, os; print(os.path.join(sysconfig.get_paths()['purelib'], 'opentimelineio'))"
+        $sourceDir = "C:/vcpkg/installed/x64-windows/bin"
+        Write-Host "Target: $target"
+        Write-Host "Contents of ${sourceDir}:"
+        Get-ChildItem $sourceDir -ErrorAction SilentlyContinue | ForEach-Object { Write-Host " $($_.Name)" }
+        Copy-Item "$sourceDir/*.dll" "$target/" -ErrorAction Stop
+        Write-Host "DLLs now in ${target}:"
+        Get-ChildItem "$target/*.dll" | ForEach-Object { Write-Host " $($_.Name)" }
 
     - name: Run Unit Tests
       shell: bash

--- a/tests/test_aaf_adapter.py
+++ b/tests/test_aaf_adapter.py
@@ -1365,17 +1365,17 @@ class AAFReaderTests(unittest.TestCase):
         fps = 24.0
         expected_markers = [
             {
-                'color': 'RED',
+                'color': otio.schema.MarkerColor.RED,
                 'label': 'm1',
                 'start_time': otio.opentime.from_frames(50.0, fps)
             },
             {
-                'color': 'GREEN',
+                'color': otio.schema.MarkerColor.GREEN,
                 'label': 'm2',
                 'start_time': otio.opentime.from_frames(103.0, fps)
             },
             {
-                'color': 'BLUE',
+                'color': otio.schema.MarkerColor.BLUE,
                 'label': 'm3',
                 'start_time': otio.opentime.from_frames(166.0, fps)
             }
@@ -1465,37 +1465,38 @@ class AAFReaderTests(unittest.TestCase):
         timeline = otio.adapters.read_from_file(MULTIPLE_MARKERS_PATH,
                                                 attach_markers=True)
 
+        Color = otio.schema.MarkerColor
         expected_markers = {
-            (0, 'Filler'): [('PUBLISH', 0.0, 1.0, 24.0, 'RED')],
+            (0, 'Filler'): [('PUBLISH', 0.0, 1.0, 24.0, Color.RED)],
             (0, 'zts02_1010'): [
                 ('GREEN: V1: zts02_1010: f1104: seq.f1104',
-                 1104.0, 1.0, 24.0, 'GREEN')
+                 1104.0, 1.0, 24.0, Color.GREEN)
             ],
             (1, 'ScopeReference'): [
-                ('FX', 0.0, 1.0, 24.0, 'YELLOW'),
+                ('FX', 0.0, 1.0, 24.0, Color.YELLOW),
                 ('BLUE: V2 (no FX): zts02_1020: f1134: seq.f1327',
-                 518.0, 1.0, 24.0, 'BLUE')
+                 518.0, 1.0, 24.0, Color.BLUE)
             ],
             (2, 'ScopeReference'): [
-                ('INSERT', 0.0, 1.0, 24.0, 'CYAN'),
+                ('INSERT', 0.0, 1.0, 24.0, Color.CYAN),
                 ('CYAN: V3: zts02_1030: f1212: seq.f1665',
                  856.0,
                  1.0,
                  24.0,
-                 'CYAN')
+                 Color.CYAN)
             ],
             (3, 'Drop_24.mov'): [
                 ('MAGENTA: V4: zts02_1040: f1001: seq.f1666',
-                 86400.0, 1.0, 24.0, 'MAGENTA')
+                 86400.0, 1.0, 24.0, Color.MAGENTA)
             ],
             (3, 'Flow_07.mov'): [('GREEN: TC1: zts02_1080: f1206: seq.f2604',
                                   -207.0,  # this marker should probably discarded?
                                   1.0,
                                   24.0,
-                                  'GREEN')],
+                                  Color.GREEN)],
             (4, 'ScopeReference'): [
                 ('RED: V5: zts02_1050: f1061: seq.f1885',
-                 884.0, 1.0, 24.0, 'RED')
+                 884.0, 1.0, 24.0, Color.RED)
             ]
         }
 


### PR DESCRIPTION
### Changes

The recent merge of the OTIOZ work introduced a change in CI configuration that is currently required to pass on Windows. We now need to install ZLib explicitly on Windows for OTIO wheel builds, as its now required by OTIO, but not provided by the vanilla runners.  See https://github.com/AcademySoftwareFoundation/OpenTimelineIO/pull/2021

It also fixes an issue with the tests introduced by the marker color PR which landed (https://github.com/AcademySoftwareFoundation/OpenTimelineIO/issues/1873)

